### PR TITLE
When LINUX is defined, only define KYLIX under Delphi 6

### DIFF
--- a/jedi.inc
+++ b/jedi.inc
@@ -629,7 +629,9 @@
 
 {$IFDEF BORLAND}
   {$IFDEF LINUX}
-    {$DEFINE KYLIX}
+    {$IFDEF VER140} // Only under Delphi 6, LINUX implies Kylix
+      {$DEFINE KYLIX}
+    {$ENDIF}
   {$ENDIF LINUX}
   {$IFNDEF CLR}
     {$IFNDEF CPUX86}


### PR DESCRIPTION
 (especially prudent since Delphi 10.2 defines LINUX for Linux platform build targets).