### PR TITLE
Set {$AsmMode Intel} only for x86 CPU family

### DIFF
--- a/jedi.inc
+++ b/jedi.inc
@@ -639,7 +639,10 @@
 { Set FreePascal to Delphi mode }
 {$IFDEF FPC}
   {$MODE DELPHI}
-  {$ASMMODE Intel}
+  // Assembler mode Intel is only available for the x86 CPU family
+  {$IF DEFINED(CPUI8086) OR DEFINED(CPUI386) OR DEFINED(CPUX86_64)}
+    {$ASMMODE Intel}
+  {$ENDIF}
   {$UNDEF BORLAND}
   {$DEFINE CPUASM}
    // FPC defines CPU32, CPU64 and Unix automatically

--- a/jedi.inc
+++ b/jedi.inc
@@ -642,7 +642,7 @@
   // Assembler mode Intel is only available for the x86 CPU family
   {$IF DEFINED(CPUI8086) OR DEFINED(CPUI386) OR DEFINED(CPUX86_64)}
     {$ASMMODE Intel}
-  {$ENDIF}
+  {$IFEND}
   {$UNDEF BORLAND}
   {$DEFINE CPUASM}
    // FPC defines CPU32, CPU64 and Unix automatically


### PR DESCRIPTION
FPC supports the assembler mode Intel only for the x86 CPU family. As I recently ported FPC for Windows on ARM64 I noticed that _jedi.inc_ sets it unconditionally. This pull request solves this (and yes, this time I've tested with Delphi as well ;) )