### PR TITLE
Update for use in FPC with Raspberry Pi (Linux arm)

### DIFF
--- a/jedi.inc
+++ b/jedi.inc
@@ -666,7 +666,9 @@
 { Set FreePascal to Delphi mode }
 {$IFDEF FPC}
   {$MODE DELPHI}
-  {$ASMMODE Intel}
+  {$IFNDEF CPUARM} 
+    {$ASMMODE Intel}
+  {$ENDIF}
   {$UNDEF BORLAND}
   {$DEFINE CPUASM}
    // FPC defines CPU32, CPU64 and Unix automatically


### PR DESCRIPTION
When using Arm, Do not define "Intel" as ASMMODE.